### PR TITLE
enable packages list merge

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,9 +1,12 @@
 ---
+lookup_options:
+  tuned::package_names:
+    merge: unique
+
 tuned::package_names:
   - tuned
 
 tuned::packages_ensure: installed
-
 
 tuned::service_names:
   - tuned.service


### PR DESCRIPTION
allow defining additional packages, like tuned-profiles-postgresql, to be managed on a role hiera level

